### PR TITLE
Remove degree-zero vertices from steiner_tree output

### DIFF
--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -9,13 +9,9 @@ using SimpleTraits: SimpleTraits, Not, @traitfn
     map(v -> vertex_positions(g)[v], term_vert),
     dist_matrix_to_position_dist_matrix(g, distmx),
   )
-  named_st = typeof(g)(
-    position_tree, map(v -> ordered_vertices(g)[v], vertices(position_tree))
-  )
-  # Detect and remove vertices of degree zero
-  zero_verts = filter(v -> degree(named_st, v) == 0, vertices(named_st))
-  for v in zero_verts
-    rem_vertex!(named_st, v)
+  tree = typeof(g)(position_tree, map(v -> ordered_vertices(g)[v], vertices(position_tree)))
+  for v in copy(vertices(tree))
+    iszero(degree(tree, v)) && rem_vertex!(tree, v)
   end
-  return named_st
+  return tree
 end

--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -9,5 +9,13 @@ using SimpleTraits: SimpleTraits, Not, @traitfn
     map(v -> vertex_positions(g)[v], term_vert),
     dist_matrix_to_position_dist_matrix(g, distmx),
   )
-  return typeof(g)(position_tree, map(v -> ordered_vertices(g)[v], vertices(position_tree)))
+  named_st = typeof(g)(
+    position_tree, map(v -> ordered_vertices(g)[v], vertices(position_tree))
+  )
+  # Detect and remove vertices of degree zero
+  zero_verts = filter(v -> degree(named_st, v) == 0, vertices(named_st))
+  for v in zero_verts
+    rem_vertex!(named_st, v)
+  end
+  return named_st
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -675,7 +675,10 @@ end
     st = steiner_tree(g, terminal_vertices)
     es = [(1, 2) => (1, 3), (1, 3) => (1, 4), (1, 4) => (2, 4), (2, 4) => (3, 4)]
     @test ne(st) == 4
-    @test nv(st) == 12
+    @test nv(st) == 5
+    # Test that there are no degree-zero vertices in output:
+    zv = filter(v -> degree(st, v) == 0, vertices(st))
+    @test isempty(zv)
     for e in es
       @test has_edge(st, e)
     end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -676,7 +676,7 @@ end
     es = [(1, 2) => (1, 3), (1, 3) => (1, 4), (1, 4) => (2, 4), (2, 4) => (3, 4)]
     @test ne(st) == 4
     @test nv(st) == 5
-    @test !any(v -> degree(st, v) == 0, vertices(st))
+    @test !any(v -> iszero(degree(st, v)), vertices(st))
     for e in es
       @test has_edge(st, e)
     end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -677,8 +677,8 @@ end
     @test ne(st) == 4
     @test nv(st) == 5
     # Test that there are no degree-zero vertices in output:
-    zv = filter(v -> degree(st, v) == 0, vertices(st))
-    @test isempty(zv)
+    zero_deg_verts = filter(v -> degree(st, v) == 0, vertices(st))
+    @test isempty(zero_deg_verts)
     for e in es
       @test has_edge(st, e)
     end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -676,9 +676,7 @@ end
     es = [(1, 2) => (1, 3), (1, 3) => (1, 4), (1, 4) => (2, 4), (2, 4) => (3, 4)]
     @test ne(st) == 4
     @test nv(st) == 5
-    # Test that there are no degree-zero vertices in output:
-    zero_deg_verts = filter(v -> degree(st, v) == 0, vertices(st))
-    @test isempty(zero_deg_verts)
+    @test !any(v -> degree(st, v) == 0, vertices(st))
     for e in es
       @test has_edge(st, e)
     end


### PR DESCRIPTION
This PR fixes #80 by removing any vertices of degree zero from the NamedGraph output by the function `steiner_tree`. It also adds a test of this new behavior. (The graph already used in the previous test resulting in many degree-zero vertices so was already a good test case.)
