### PR TITLE
Fix ambiguity error on `Steiner_Tree`

### DIFF
--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -1,7 +1,7 @@
 using Graphs: Graphs, IsDirected, nv, steiner_tree
 using SimpleTraits: SimpleTraits, Not, @traitfn
 
-@traitfn function Graphs.steiner_tree(
+@traitfn function namedgraph_steiner_tree(
   g::AbstractNamedGraph::(!IsDirected), term_vert, distmx=weights(g)
 )
   position_tree = steiner_tree(
@@ -10,4 +10,16 @@ using SimpleTraits: SimpleTraits, Not, @traitfn
     dist_matrix_to_position_dist_matrix(g, distmx),
   )
   return typeof(g)(position_tree, map(v -> ordered_vertices(g)[v], vertices(position_tree)))
+end
+
+@traitfn function Graphs.steiner_tree(
+  g::AbstractNamedGraph::(!IsDirected), term_vert, args...
+)
+  return namedgraph_steiner_tree(g, term_vert, args...)
+end
+
+@traitfn function Graphs.steiner_tree(
+  g::AbstractNamedGraph::(!IsDirected), term_vert::Vector{<:Integer}, args...
+)
+  return namedgraph_steiner_tree(g, term_vert, args...)
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -679,6 +679,16 @@ end
     for e in es
       @test has_edge(st, e)
     end
+
+    g = named_path_graph(4)
+    terminal_vertices = [1, 3]
+    st = steiner_tree(g, terminal_vertices)
+    es = [1 => 2, 2 => 3]
+    @test ne(st) == 2
+    @test nv(st) == 3
+    for e in es
+      @test has_edge(st, e)
+    end
   end
   @testset "topological_sort_by_dfs" begin
     g = NamedDiGraph(["A", "B", "C", "D", "E", "F", "G"])


### PR DESCRIPTION
This PR fixes an ambiguity error on `Steiner_Tree` which prevents it being called on a `NamedGraph` with vertices labelled as integers. A test is added.