### PR TITLE
Partitioned graphs bug fix

### DIFF
--- a/src/lib/PartitionedGraphs/src/partitionedgraph.jl
+++ b/src/lib/PartitionedGraphs/src/partitionedgraph.jl
@@ -90,11 +90,11 @@ function partitionedges(pg::PartitionedGraph)
 end
 
 function Graphs.edges(pg::PartitionedGraph, partitionedge::PartitionEdge)
-  psrc_vs = vertices(pg, PartitionVertex(src(partitionedge)))
-  pdst_vs = vertices(pg, PartitionVertex(dst(partitionedge)))
-  psrc_subgraph = subgraph(unpartitioned_graph(pg), psrc_vs)
-  pdst_subgraph = subgraph(pg, pdst_vs)
-  full_subgraph = subgraph(pg, vcat(psrc_vs, pdst_vs))
+  psrc_vs = vertices(pg, src(partitionedge))
+  pdst_vs = vertices(pg, dst(partitionedge))
+  psrc_subgraph, _ = induced_subgraph(unpartitioned_graph(pg), psrc_vs)
+  pdst_subgraph, _ = induced_subgraph(pg, pdst_vs)
+  full_subgraph, _ = induced_subgraph(pg, vcat(psrc_vs, pdst_vs))
 
   return setdiff(edges(full_subgraph), vcat(edges(psrc_subgraph), edges(pdst_subgraph)))
 end

--- a/src/steiner_tree.jl
+++ b/src/steiner_tree.jl
@@ -1,7 +1,7 @@
 using Graphs: Graphs, IsDirected, nv, steiner_tree
 using SimpleTraits: SimpleTraits, Not, @traitfn
 
-@traitfn function Graphs.steiner_tree(
+@traitfn function namedgraph_steiner_tree(
   g::AbstractNamedGraph::(!IsDirected), term_vert, distmx=weights(g)
 )
   position_tree = steiner_tree(
@@ -10,4 +10,16 @@ using SimpleTraits: SimpleTraits, Not, @traitfn
     dist_matrix_to_position_dist_matrix(g, distmx),
   )
   return typeof(g)(position_tree, map(v -> ordered_vertices(g)[v], vertices(position_tree)))
+end
+
+@traitfn function Graphs.steiner_tree(
+  g::AbstractNamedGraph::(!IsDirected), term_vert, args...
+)
+  return namedgraph_steiner_tree(g, term_vert, args...)
+end
+
+@traitfn function Graphs.steiner_tree(
+  g::AbstractNamedGraph::(!IsDirected), term_vert::Vector{<:Integer}, args...
+)
+  return namedgraph_steiner_tree(g, term_vert, args...)
 end

--- a/test/test_namedgraph.jl
+++ b/test/test_namedgraph.jl
@@ -679,6 +679,16 @@ end
     for e in es
       @test has_edge(st, e)
     end
+
+    g = named_path_graph(4)
+    terminal_vertices = [1, 3]
+    st = steiner_tree(g, terminal_vertices)
+    es = [1 => 2, 2 => 3]
+    @test ne(st) == 2
+    @test nv(st) == 3
+    for e in es
+      @test has_edge(st, e)
+    end
   end
   @testset "topological_sort_by_dfs" begin
     g = NamedDiGraph(["A", "B", "C", "D", "E", "F", "G"])

--- a/test/test_partitionedgraph.jl
+++ b/test/test_partitionedgraph.jl
@@ -28,6 +28,7 @@ using NamedGraphs.GraphsExtensions:
   vertextype
 using NamedGraphs.NamedGraphGenerators:
   named_comb_tree, named_grid, named_triangular_lattice_graph
+using NamedGraphs.OrderedDictionaries: OrderedDictionary
 using NamedGraphs.PartitionedGraphs:
   PartitionEdge,
   PartitionedGraph,
@@ -52,7 +53,7 @@ using Test: @test, @testset
   pg = PartitionedGraph(g, partitions)
   @test vertextype(partitioned_graph(pg)) == Int64
   @test vertextype(unpartitioned_graph(pg)) == vertextype(g)
-  @test isa(partitionvertices(pg), Dictionary{Int64,PartitionVertex{Int64}})
+  @test isa(partitionvertices(pg), OrderedDictionary{Int64,PartitionVertex{Int64}})
   @test isa(partitionedges(pg), Vector{PartitionEdge{Int64,NamedEdge{Int64}}})
   @test is_tree(partitioned_graph(pg))
   @test nv(pg) == nx * ny
@@ -67,7 +68,7 @@ using Test: @test, @testset
   @test vertextype(unpartitioned_graph(pg)) == vertextype(g)
   @test isa(
     partitionvertices(pg),
-    Dictionary{Tuple{Int64,Int64},PartitionVertex{Tuple{Int64,Int64}}},
+    OrderedDictionary{Tuple{Int64,Int64},PartitionVertex{Tuple{Int64,Int64}}},
   )
   @test isa(
     partitionedges(pg),
@@ -103,6 +104,7 @@ end
   @test !is_self_loop(partitionedge(pg, (1, 2, 1) => (1, 1, 1)))
   @test partitionvertex(pg, (1, 1, 1)) == partitionvertex(pg, (1, 1, nz))
   @test partitionvertex(pg, (2, 1, 1)) != partitionvertex(pg, (1, 1, nz))
+  @test all([length(edges(pg, pe)) == nz for pe in partitionedges(pg)])
 
   @test partitionedge(pg, (1, 1, 1) => (2, 1, 1)) ==
     partitionedge(pg, (1, 1, 2) => (2, 1, 2))


### PR DESCRIPTION
This PR fixes a bug with the `edges(pg::PartitionedGraph, pe::PartitionEdge)` function which was wrapping the call to `src(pe)` in a `PartitionVertex` type despite `src(pe::PartitionEdge)` already doing that wrapping.
A test is added to catch the issue and two `PartitionedGraph` tests are also modified as they were failing due to the introduction of `OrderedDictionaries` 